### PR TITLE
Add interactive Three.js hero canvas with fallback visuals

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <link rel="icon" type="image/x-icon" href="./assets/ch.svg" />
     <script src="https://kit.fontawesome.com/f6cc9abe5a.js" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/@emailjs/browser@3/dist/email.min.js"></script>
-    <script src="index.js" defer></script>
+    <script type="module" src="index.js"></script>
     <script>
       (function () {
         emailjs.init("i4Ysn7FwxaL2UqEMV");
@@ -16,7 +16,7 @@
     </script>
   </head>
   <body>
-    <section id="landing-page" onmousemove="moveBackground(event)">
+    <section id="landing-page">
       <nav class="nav">
         <a href="#landing-page" class="logo-wrap">
           <img id="personal-logo" src="./assets/ch.svg" alt="Charlie logo" />
@@ -32,6 +32,14 @@
           </li>
         </ul>
       </nav>
+
+      <div class="hero-visual" aria-hidden="true">
+        <div id="hero-canvas"></div>
+        <div class="hero-visual__fallback">
+          <span class="fallback-glow fallback-glow--one"></span>
+          <span class="fallback-glow fallback-glow--two"></span>
+        </div>
+      </div>
 
       <header class="hero header">
         <p class="eyebrow">Software Engineer · Sydney</p>

--- a/index.js
+++ b/index.js
@@ -1,13 +1,24 @@
+import * as THREE from "https://unpkg.com/three@0.164.1/build/three.module.js";
+
 let isModalOpen = false;
 let isContrastOn = false;
 const scaleFactor = 1 / 28;
 
 const yearElement = document.getElementById("year");
-if (yearElement) {
-  yearElement.textContent = new Date().getFullYear();
-}
+if (yearElement) yearElement.textContent = new Date().getFullYear();
+
+const heroState = {
+  targetX: 0,
+  targetY: 0,
+  currentX: 0,
+  currentY: 0,
+  enabled: false,
+};
 
 function moveBackground(event) {
+  heroState.targetX = (event.clientX / window.innerWidth - 0.5) * 2;
+  heroState.targetY = (event.clientY / window.innerHeight - 0.5) * 2;
+
   const shapes = document.querySelectorAll(".shape");
   const x = event.clientX * scaleFactor;
   const y = event.clientY * scaleFactor;
@@ -16,6 +27,85 @@ function moveBackground(event) {
     const direction = index % 2 === 0 ? 1 : -1;
     shape.style.transform = `translate(${x * direction}px, ${y * direction}px)`;
   });
+}
+
+function initHeroVisual() {
+  const canvasMount = document.getElementById("hero-canvas");
+  if (!canvasMount) return;
+
+  const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  const isMobile = window.matchMedia("(max-width: 900px)").matches;
+  const hasWebGL = !!window.WebGLRenderingContext;
+
+  document.getElementById("landing-page")?.addEventListener("mousemove", moveBackground, { passive: true });
+
+  if (!hasWebGL || reduceMotion || isMobile) {
+    document.body.classList.add("hero-fallback-only");
+    return;
+  }
+
+  document.body.classList.add("hero-webgl-enabled");
+  heroState.enabled = true;
+
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera(45, canvasMount.clientWidth / canvasMount.clientHeight, 0.1, 100);
+  camera.position.set(0, 0, 5.5);
+
+  const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true, powerPreference: "high-performance" });
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 1.75));
+  renderer.setSize(canvasMount.clientWidth, canvasMount.clientHeight);
+  canvasMount.appendChild(renderer.domElement);
+
+  const geo = new THREE.IcosahedronGeometry(1.4, 18);
+  const mat = new THREE.MeshPhysicalMaterial({
+    color: 0x9cc6ff,
+    roughness: 0.08,
+    transmission: 0.9,
+    thickness: 1.2,
+    transparent: true,
+    opacity: 0.95,
+    metalness: 0.1,
+    ior: 1.3,
+  });
+  const orb = new THREE.Mesh(geo, mat);
+  scene.add(orb);
+
+  scene.add(new THREE.AmbientLight(0xcfe0ff, 0.8));
+  const light = new THREE.PointLight(0x63a3ff, 2.1, 25);
+  light.position.set(2, 2, 3);
+  scene.add(light);
+
+  const clock = new THREE.Clock();
+
+  function onResize() {
+    const w = canvasMount.clientWidth;
+    const h = canvasMount.clientHeight;
+    camera.aspect = w / h;
+    camera.updateProjectionMatrix();
+    renderer.setSize(w, h);
+  }
+  window.addEventListener("resize", onResize);
+
+  function tick() {
+    if (!heroState.enabled) return;
+    const t = clock.getElapsedTime();
+    heroState.currentX += (heroState.targetX - heroState.currentX) * 0.06;
+    heroState.currentY += (heroState.targetY - heroState.currentY) * 0.06;
+
+    orb.rotation.y = t * 0.3;
+    orb.rotation.x = t * 0.15 + heroState.currentY * 0.2;
+    orb.position.x = heroState.currentX * 0.25;
+    orb.position.y = -heroState.currentY * 0.2;
+
+    camera.position.x += (heroState.currentX * 0.45 - camera.position.x) * 0.05;
+    camera.position.y += (-heroState.currentY * 0.35 - camera.position.y) * 0.05;
+    camera.lookAt(0, 0, 0);
+
+    renderer.render(scene, camera);
+    requestAnimationFrame(tick);
+  }
+
+  tick();
 }
 
 function toggleContrast() {
@@ -50,3 +140,10 @@ function toggleModal() {
 function scrollToTop() {
   window.scrollTo({ top: 0, behavior: "smooth" });
 }
+
+window.toggleContrast = toggleContrast;
+window.contact = contact;
+window.toggleModal = toggleModal;
+window.scrollToTop = scrollToTop;
+
+initHeroVisual();

--- a/style.css
+++ b/style.css
@@ -35,6 +35,77 @@ button { border: none; background: none; cursor: pointer; }
   position: relative;
 }
 
+
+#landing-page::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(110deg, rgba(244, 248, 255, 0.92) 0%, rgba(244, 248, 255, 0.7) 38%, rgba(244, 248, 255, 0.35) 62%, rgba(244, 248, 255, 0.16) 100%);
+  z-index: 1;
+  pointer-events: none;
+}
+
+.hero-visual {
+  position: absolute;
+  inset: 0 0 0 48%;
+  z-index: 0;
+  overflow: hidden;
+}
+
+#hero-canvas {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+}
+
+.hero-visual::after {
+  content: "";
+  position: absolute;
+  width: 520px;
+  height: 520px;
+  right: -120px;
+  top: 6%;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(85, 144, 255, 0.4), rgba(18, 211, 207, 0.1) 40%, transparent 70%);
+  mix-blend-mode: screen;
+  filter: blur(20px);
+  z-index: 2;
+  pointer-events: none;
+}
+
+.hero-visual__fallback {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 62% 38%, rgba(75, 107, 255, 0.28), transparent 36%),
+    radial-gradient(circle at 78% 62%, rgba(18, 211, 207, 0.18), transparent 42%),
+    linear-gradient(145deg, rgba(255, 255, 255, 0.2), rgba(75, 107, 255, 0.1));
+  backdrop-filter: blur(10px);
+  z-index: 0;
+}
+
+.fallback-glow {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(30px);
+  opacity: 0.7;
+}
+
+.fallback-glow--one { width: 340px; height: 340px; right: 12%; top: 18%; background: rgba(75, 107, 255, 0.4); }
+.fallback-glow--two { width: 270px; height: 270px; right: 28%; bottom: 14%; background: rgba(18, 211, 207, 0.3); }
+
+.hero { max-width: 760px; }
+
+.hero-webgl-enabled .hero-visual__fallback { opacity: 0.42; }
+
+.dark-theme #landing-page::before {
+  background: linear-gradient(110deg, rgba(12, 19, 39, 0.92) 0%, rgba(12, 19, 39, 0.74) 38%, rgba(12, 19, 39, 0.4) 62%, rgba(12, 19, 39, 0.16) 100%);
+}
+
+@media (max-width: 900px) {
+  .hero-visual { inset: 14% -10% 10% 22%; opacity: 0.8; }
+  #landing-page::before { background: linear-gradient(180deg, rgba(244, 248, 255, 0.92) 0%, rgba(244, 248, 255, 0.84) 54%, rgba(244, 248, 255, 0.66) 100%); }
+}
+
 .nav {
   width: min(1150px, 92%);
   margin: 0 auto;


### PR DESCRIPTION
### Motivation
- Introduce a lightweight, interactive 3D hero to give the landing area more depth while preserving legibility of the intro text.
- Keep the experience performant and accessible by disabling heavy WebGL effects on mobile and when `prefers-reduced-motion` is set.
- Provide a graceful CSS fallback so non-WebGL or motion-reduced environments still show a polished visual.

### Description
- Added a dedicated hero visual container inside `#landing-page` (`<div class="hero-visual"><div id="hero-canvas">…</div>…</div>`) and switched the page script to module mode so Three.js can be imported. (`index.html`)
- Implemented `initHeroVisual()` in `index.js` that mounts a vanilla Three.js scene with a lightweight glass-like orb (`IcosahedronGeometry` + `MeshPhysicalMaterial`), ambient + point lighting, an animation loop, and resize handling.
- Reworked `moveBackground()` to produce mouse target coordinates used for camera/object parallax and lerp smoothing, and wire the page-level `mousemove` listener from JS; re-exposed `toggleModal`, `toggleContrast`, `contact`, and `scrollToTop` on `window` so existing inline handlers continue to work. (`index.js`)
- Added performance gating to disable WebGL on mobile (`max-width: 900px`) and when `prefers-reduced-motion` is enabled, and added a CSS fallback visual (radial gradients + blurred glow layers) plus layered gradient/fog overlays to keep hero text readable. (`style.css`)

### Testing
- Ran a Node smoke command `node -e "console.log('node ok')"` which executed successfully in the environment.
- Attempted to run `npx --yes playwright --version` for visual/screenshot testing but it failed due to an npm registry permission error (403), preventing further automated screenshot tests in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7342894dc832bb19a35dcc6a329bc)