### PR TITLE
Replace contact modal with responsive drawer and inline EmailJS feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
         <ul class="nav__link--list">
           <li><a href="#about" class="nav__link--anchor">About</a></li>
           <li><a href="#projects" class="nav__link--anchor">Projects</a></li>
-          <li><a href="#" class="nav__link--anchor" onclick="toggleModal()">Contact</a></li>
+          <li><button type="button" class="nav__link--anchor nav__link--button" onclick="toggleModal()">Contact</button></li>
           <li>
             <button class="theme-toggle" onclick="toggleContrast()" aria-label="Toggle theme">
               <i class="fas fa-adjust"></i>
@@ -133,41 +133,43 @@
         <div class="footer__social--list">
           <a href="https://github.com/CharlieH7" target="_blank">GitHub</a>
           <a href="https://www.linkedin.com/in/pin-hsun-huang/" target="_blank">LinkedIn</a>
-          <a href="#" onclick="toggleModal()">Contact</a>
+          <button type="button" class="footer__contact" onclick="toggleModal()">Contact</button>
           <a href="./assets/Resume.pdf" target="_blank">Resume</a>
         </div>
         <div class="footer__copyright">Copyright © <span id="year"></span> Charlie Huang</div>
       </div>
     </footer>
 
-    <div class="modal">
-      <div class="modal__half modal__about">
-        <h3 class="modal__title">Let's build something great.</h3>
+    <div class="modal" id="contact-modal" role="dialog" aria-modal="true" aria-labelledby="contact-title" aria-hidden="true">
+      <button type="button" class="modal__overlay" aria-label="Close contact panel" onclick="toggleModal()"></button>
+      <aside class="modal__panel" role="document" tabindex="-1">
+        <button type="button" class="modal__close" aria-label="Close contact panel" onclick="toggleModal()">
+          <i class="fas fa-times"></i>
+        </button>
+        <h3 class="modal__title" id="contact-title">Get in touch</h3>
         <p class="modal__paragraph">
           I'm currently open to frontend roles and freelance work. If you're looking for someone who can ship polished web experiences fast, send me a message.
         </p>
-      </div>
-      <div class="modal__half modal__contact">
-        <i class="fas fa-times modal__exit" onclick="toggleModal()"></i>
-        <h3 class="modal__title">Get in touch</h3>
         <form id="contact__form" onsubmit="contact(event)">
           <div class="form__item">
-            <label>Name</label>
-            <input class="input" name="user_name" type="text" required />
+            <label for="contact-name">Name</label>
+            <input id="contact-name" class="input" name="user_name" type="text" required />
           </div>
           <div class="form__item">
-            <label>Email</label>
-            <input class="input" name="user_email" type="email" required />
+            <label for="contact-email">Email</label>
+            <input id="contact-email" class="input" name="user_email" type="email" required />
           </div>
           <div class="form__item">
-            <label>Message</label>
-            <textarea class="input" name="message" required></textarea>
+            <label for="contact-message">Message</label>
+            <textarea id="contact-message" class="input" name="message" required></textarea>
           </div>
-          <button id="contact__submit" class="form__submit">Send message</button>
+          <button id="contact__submit" class="form__submit" type="submit">
+            <span class="form__submit-text">Send message</span>
+            <span class="form__submit-spinner" aria-hidden="true"><i class="fas fa-spinner"></i></span>
+          </button>
+          <p id="form-status" class="form__status" aria-live="polite"></p>
         </form>
-        <div class="modal__overlay modal__overlay--loading"><i class="fas fa-spinner"></i></div>
-        <div class="modal__overlay modal__overlay--success">Thanks for the message! I will get back to you soon.</div>
-      </div>
+      </aside>
     </div>
 
     <button id="back-to-top-button" onclick="scrollToTop()"><i class="fas fa-chevron-up"></i></button>

--- a/index.js
+++ b/index.js
@@ -3,6 +3,12 @@ let isContrastOn = false;
 const scaleFactor = 1 / 28;
 
 const yearElement = document.getElementById("year");
+const modalElement = document.getElementById("contact-modal");
+const modalPanel = modalElement?.querySelector(".modal__panel");
+const formStatus = document.getElementById("form-status");
+const submitButton = document.getElementById("contact__submit");
+let previousFocusedElement = null;
+
 if (yearElement) {
   yearElement.textContent = new Date().getFullYear();
 }
@@ -23,28 +29,91 @@ function toggleContrast() {
   document.body.classList.toggle("dark-theme", isContrastOn);
 }
 
+function setFormStatus(type, message) {
+  if (!formStatus) return;
+  formStatus.className = `form__status form__status--${type}`;
+  formStatus.textContent = message;
+}
+
+function setSubmitLoading(isLoading) {
+  if (!submitButton) return;
+  submitButton.classList.toggle("is-loading", isLoading);
+  submitButton.disabled = isLoading;
+}
+
 function contact(event) {
   event.preventDefault();
-  const loading = document.querySelector(".modal__overlay--loading");
-  const success = document.querySelector(".modal__overlay--success");
+  setSubmitLoading(true);
+  setFormStatus("idle", "");
 
-  loading.classList.add("modal__overlay--visible");
   emailjs
     .sendForm("service_mgbw47z", "template_cu21ivk", event.target, "i4Ysn7FwxaL2UqEMV")
     .then(() => {
-      loading.classList.remove("modal__overlay--visible");
-      success.classList.add("modal__overlay--visible");
+      setSubmitLoading(false);
+      setFormStatus("success", "Thanks for the message! I will get back to you soon.");
       event.target.reset();
     })
     .catch(() => {
-      loading.classList.remove("modal__overlay--visible");
-      alert("The email service is temporarily unavailable. Please contact me directly on LinkedIn.");
+      setSubmitLoading(false);
+      setFormStatus("error", "The email service is temporarily unavailable. Please contact me directly on LinkedIn.");
     });
 }
 
+function trapFocus(event) {
+  if (!isModalOpen || event.key !== "Tab" || !modalElement) return;
+
+  const focusableElements = modalElement.querySelectorAll(
+    'button:not([disabled]), input:not([disabled]), textarea:not([disabled]), a[href], [tabindex]:not([tabindex="-1"])'
+  );
+
+  if (!focusableElements.length) return;
+
+  const first = focusableElements[0];
+  const last = focusableElements[focusableElements.length - 1];
+
+  if (event.shiftKey && document.activeElement === first) {
+    event.preventDefault();
+    last.focus();
+  } else if (!event.shiftKey && document.activeElement === last) {
+    event.preventDefault();
+    first.focus();
+  }
+}
+
+function onModalKeyDown(event) {
+  if (event.key === "Escape" && isModalOpen) {
+    closeModal();
+    return;
+  }
+
+  trapFocus(event);
+}
+
+function openModal() {
+  if (!modalElement) return;
+  previousFocusedElement = document.activeElement;
+  isModalOpen = true;
+  document.body.classList.add("modal--open", "body--no-scroll");
+  modalElement.setAttribute("aria-hidden", "false");
+  document.addEventListener("keydown", onModalKeyDown);
+  setTimeout(() => modalPanel?.focus(), 20);
+}
+
+function closeModal() {
+  if (!modalElement) return;
+  isModalOpen = false;
+  document.body.classList.remove("modal--open", "body--no-scroll");
+  modalElement.setAttribute("aria-hidden", "true");
+  document.removeEventListener("keydown", onModalKeyDown);
+  previousFocusedElement?.focus?.();
+}
+
 function toggleModal() {
-  isModalOpen = !isModalOpen;
-  document.body.classList.toggle("modal--open", isModalOpen);
+  if (isModalOpen) {
+    closeModal();
+  } else {
+    openModal();
+  }
 }
 
 function scrollToTop() {

--- a/style.css
+++ b/style.css
@@ -13,6 +13,7 @@
 * { box-sizing: border-box; margin: 0; padding: 0; font-family: "Inter", sans-serif; }
 html { scroll-behavior: smooth; }
 body { background: var(--bg); color: var(--text); }
+body.body--no-scroll { overflow: hidden; }
 a { text-decoration: none; color: inherit; }
 button { border: none; background: none; cursor: pointer; }
 
@@ -28,24 +29,12 @@ button { border: none; background: none; cursor: pointer; }
 .section__title { font-size: clamp(2rem, 4vw, 2.8rem); margin-bottom: 20px; }
 .section__lead { color: var(--muted); max-width: 70ch; line-height: 1.75; }
 
-#landing-page {
-  min-height: 100vh;
-  padding: 24px 0 72px;
-  overflow: hidden;
-  position: relative;
-}
-
-.nav {
-  width: min(1150px, 92%);
-  margin: 0 auto;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
+#landing-page { min-height: 100vh; padding: 24px 0 72px; overflow: hidden; position: relative; }
+.nav { width: min(1150px, 92%); margin: 0 auto; display: flex; justify-content: space-between; align-items: center; }
 #personal-logo { width: 48px; }
 .nav__link--list { list-style: none; display: flex; align-items: center; gap: 28px; }
 .nav__link--anchor { color: var(--muted); font-weight: 600; }
+.nav__link--button { font-size: 1rem; }
 .theme-toggle { font-size: 1.1rem; color: var(--muted); }
 
 .hero { width: min(1150px, 92%); margin: 90px auto 0; position: relative; z-index: 2; }
@@ -59,22 +48,13 @@ button { border: none; background: none; cursor: pointer; }
 .btn--ghost { border: 1px solid #cad5f1; color: var(--text); background: rgba(255, 255, 255, 0.6); }
 
 .social__list { margin-top: 26px; display: flex; gap: 10px; }
-.social__link {
-  width: 40px; height: 40px; border-radius: 50%; display: grid; place-items: center;
-  background: var(--surface); color: var(--brand); box-shadow: var(--shadow);
-}
-
+.social__link { width: 40px; height: 40px; border-radius: 50%; display: grid; place-items: center; background: var(--surface); color: var(--brand); box-shadow: var(--shadow); }
 .scroll { position: absolute; bottom: 28px; left: 50%; transform: translateX(-50%); }
 .scroll__icon { width: 22px; height: 34px; border: 2px solid #7990bf; border-radius: 999px; position: relative; }
 .scroll__icon::after { content: ""; width: 4px; height: 8px; background: #7990bf; position: absolute; top: 7px; left: 50%; transform: translateX(-50%); border-radius: 999px; animation: scroll 1.1s infinite; }
 @keyframes scroll { 0% {opacity: 1; transform: translate(-50%,0);} 100% {opacity: 0; transform: translate(-50%,9px);} }
 
-.shape {
-  position: absolute;
-  border-radius: 50%;
-  background: radial-gradient(circle, rgba(75, 107, 255, 0.26), transparent 70%);
-  pointer-events: none;
-}
+.shape { position: absolute; border-radius: 50%; background: radial-gradient(circle, rgba(75, 107, 255, 0.26), transparent 70%); pointer-events: none; }
 .shape--0 { width: 340px; height: 340px; top: -80px; right: -60px; }
 .shape--1 { width: 240px; height: 240px; top: 48%; left: -60px; }
 .shape--2 { width: 180px; height: 180px; bottom: 10%; right: 12%; }
@@ -84,16 +64,12 @@ button { border: none; background: none; cursor: pointer; }
 .cards { margin-top: 28px; display: grid; gap: 18px; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
 .card { background: var(--surface); border-radius: 18px; padding: 24px; box-shadow: var(--shadow); }
 .card h3 { margin-bottom: 12px; }
-.card p { line-height: 1.75; color: var(--muted); }
+.card p, .project__content p, .modal__paragraph { color: var(--muted); line-height: 1.75; }
 
 .project-grid { display: grid; gap: 20px; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
-.project {
-  background: var(--surface); border-radius: 16px; overflow: hidden; box-shadow: var(--shadow);
-  display: flex; flex-direction: column;
-}
+.project { background: var(--surface); border-radius: 16px; overflow: hidden; box-shadow: var(--shadow); display: flex; flex-direction: column; }
 .project__image { width: 100%; height: 180px; object-fit: cover; }
 .project__content { padding: 18px; display: flex; flex-direction: column; gap: 12px; }
-.project__content p { color: var(--muted); line-height: 1.7; }
 .project__links { display: flex; gap: 16px; margin-top: auto; }
 .project__links a { color: var(--brand); font-weight: 700; }
 
@@ -101,58 +77,58 @@ footer { padding: 40px 0 56px; }
 .footer__row { display: flex; flex-direction: column; align-items: center; gap: 16px; text-align: center; }
 .footer__logo--image { width: 42px; }
 .footer__social--list { display: flex; gap: 16px; color: var(--muted); flex-wrap: wrap; justify-content: center; }
+.footer__contact { color: var(--muted); font-size: 1rem; }
 .footer__copyright { color: var(--muted); font-size: 0.95rem; }
 
-.mail__btn, #back-to-top-button {
-  position: fixed; right: 24px; width: 52px; height: 52px; border-radius: 50%; background: var(--brand); color: #fff;
-  box-shadow: var(--shadow); z-index: 12;
-}
+.mail__btn, #back-to-top-button { position: fixed; right: 24px; width: 52px; height: 52px; border-radius: 50%; background: var(--brand); color: #fff; box-shadow: var(--shadow); z-index: 12; }
 .mail__btn { bottom: 92px; }
 #back-to-top-button { bottom: 28px; }
 
-.modal {
-  position: fixed; inset: 0; z-index: 40; display: flex; justify-content: center; align-items: center;
-  opacity: 0; visibility: hidden; transition: 0.35s ease;
+.modal { position: fixed; inset: 0; z-index: 40; display: flex; justify-content: flex-end; align-items: stretch; pointer-events: none; }
+.modal__overlay {
+  position: absolute; inset: 0; background: rgba(6, 14, 34, 0.28); backdrop-filter: blur(0px); opacity: 0;
+  transition: opacity 320ms ease, backdrop-filter 320ms ease;
 }
-.modal::before { content: ""; position: absolute; inset: 0; background: rgba(6, 14, 34, 0.72); }
-.modal__half {
-  width: min(500px, 92vw); background: #fff; z-index: 1; padding: 30px; position: relative;
+.modal__panel {
+  position: relative; width: min(460px, 100vw); background: #fff; height: 100%; padding: 30px;
+  transform: translateX(110%); opacity: 0.75;
+  transition: transform 480ms cubic-bezier(0.22, 1.2, 0.32, 1), opacity 300ms ease;
+  box-shadow: -10px 0 40px rgba(0, 0, 0, 0.2);
+  overflow-y: auto;
 }
-.modal__about { border-radius: 16px 16px 0 0; }
-.modal__contact { border-radius: 0 0 16px 16px; }
+.modal__close { position: absolute; right: 20px; top: 16px; font-size: 1.2rem; color: var(--muted); }
 .modal__title { margin-bottom: 12px; }
-.modal__paragraph { color: var(--muted); line-height: 1.75; }
-.modal__exit { position: absolute; right: 20px; top: 16px; font-size: 1.2rem; color: var(--muted); }
 .form__item { margin-top: 12px; }
 label { display: block; margin-bottom: 6px; font-size: 0.9rem; color: var(--muted); }
 .input { width: 100%; border: 1px solid #d7def2; border-radius: 10px; padding: 11px 12px; }
 textarea.input { min-height: 110px; resize: vertical; }
-.form__submit { margin-top: 14px; width: 100%; padding: 12px; border-radius: 10px; background: var(--brand); color: #fff; font-weight: 600; }
-.modal__overlay {
-  position: absolute; inset: 0; background: #111f3d; color: #fff; display: none; place-items: center; text-align: center; padding: 24px;
+.form__submit {
+  margin-top: 14px; width: 100%; padding: 12px; border-radius: 10px; background: var(--brand); color: #fff;
+  font-weight: 600; display: inline-flex; align-items: center; justify-content: center; gap: 8px;
 }
-.modal__overlay--visible { display: grid; }
-.fa-spinner { animation: spin 700ms infinite linear; font-size: 1.7rem; }
+.form__submit-spinner { display: none; }
+.form__submit.is-loading .form__submit-spinner { display: inline-flex; }
+.form__submit.is-loading .form__submit-text { opacity: 0.85; }
+.form__submit:disabled { opacity: 0.85; cursor: wait; }
+.form__status { margin-top: 10px; min-height: 1.35rem; font-size: 0.92rem; }
+.form__status--success { color: #0f8c4a; }
+.form__status--error { color: #c63030; }
+.fa-spinner { animation: spin 700ms infinite linear; }
 @keyframes spin { to { transform: rotate(360deg);} }
 
-.modal--open .modal { opacity: 1; visibility: visible; }
+.modal--open .modal { pointer-events: auto; }
+.modal--open .modal__overlay { opacity: 1; backdrop-filter: blur(6px); }
+.modal--open .modal__panel { transform: translateX(0); opacity: 1; }
 
-.dark-theme {
-  --bg: #0c1327;
-  --surface: #101a35;
-  --text: #edf2ff;
-  --muted: #b7c4e6;
-  --shadow: 0 20px 50px rgba(0, 0, 0, 0.35);
-}
-
-@media (min-width: 900px) {
-  .modal__half { width: 420px; }
-  .modal { gap: 0; }
-  .modal__about { border-radius: 16px 0 0 16px; }
-  .modal__contact { border-radius: 0 16px 16px 0; }
-}
+.dark-theme { --bg: #0c1327; --surface: #101a35; --text: #edf2ff; --muted: #b7c4e6; --shadow: 0 20px 50px rgba(0, 0, 0, 0.35); }
 
 @media (max-width: 700px) {
   .nav__link--list { gap: 14px; font-size: 0.92rem; }
   .mail__btn, #back-to-top-button { right: 14px; }
+  .modal { justify-content: center; align-items: flex-end; }
+  .modal__panel {
+    width: 100%; max-height: min(86vh, 640px); height: auto; border-radius: 22px 22px 0 0;
+    transform: translateY(110%); box-shadow: 0 -10px 38px rgba(0, 0, 0, 0.25);
+  }
+  .modal--open .modal__panel { transform: translateY(0); }
 }


### PR DESCRIPTION
### Motivation
- Replace the existing visibility-only modal with a modern, accessible drawer that slides from the right on desktop and becomes a bottom-sheet on mobile while adding a soft backdrop blur and spring-like easing for smoother motion.
- Improve accessibility and UX by separating overlay/panel/close semantics, adding ARIA attributes, trapping focus while open, restoring focus on close, and preventing body scroll when the panel is open.
- Preserve EmailJS integration but remove blocking overlays and provide clearer form feedback with an in-button loading spinner and inline success/error messages.

### Description
- Reworked the dialog markup in `index.html` into a dedicated container with an overlay button, a panel (`aside.modal__panel`), a close button, labeled heading, `role="dialog"`, `aria-modal`, and `aria-hidden` toggling, and converted contact links to `button` triggers.
- Replaced modal toggle logic in `index.js` with explicit `openModal` / `closeModal` helpers, implemented focus trapping (`trapFocus`), Escape-to-close handling, body scroll lock (`body--no-scroll`), and focus restoration, and switched form handling to show inline status via `setFormStatus` and show an in-button spinner via `setSubmitLoading` while keeping `emailjs.sendForm`.
- Rewrote modal styles in `style.css` to animate `transform` and `opacity` with a cubic-bezier spring-like easing, added a blurred backdrop using `backdrop-filter`, and implemented responsive layouts so the panel slides in from the right on wide screens and becomes a bottom-sheet on small screens.
- Added styles for the submit button loading state and inline status messages and removed the previous full-panel loading/success overlays.

### Testing
- Ran `node --check index.js` to verify the updated JavaScript syntax and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7342c8104832ba47fdacfebd86605)